### PR TITLE
feat: Add Zero Trust Access Policies, Identity Providers, Device Profiles, and Access Users resource support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ go.work.sum
 
 # Editor/IDE
 .zed
+
+# Logs
+cf-nuke-scan-*.log

--- a/resources/accessIdentityProvider.go
+++ b/resources/accessIdentityProvider.go
@@ -1,0 +1,66 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
+
+	"github.com/arafato/cf-nuke/infrastructure"
+	"github.com/arafato/cf-nuke/types"
+	"github.com/arafato/cf-nuke/utils"
+)
+
+func init() {
+	infrastructure.RegisterAccountCollector("zt-identity-provider", CollectZTIdentityProviders)
+}
+
+type ZTIdentityProvider struct {
+	Client *zero_trust.IdentityProviderService
+}
+
+func CollectZTIdentityProviders(creds *types.Credentials) (types.Resources, error) {
+	client := utils.CreateCFClient(creds)
+
+	page, err := client.ZeroTrust.IdentityProviders.List(context.TODO(), zero_trust.IdentityProviderListParams{
+		AccountID: cloudflare.F(creds.AccountID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var allIdPs []zero_trust.IdentityProviderListResponse
+	for page != nil && len(page.Result) != 0 {
+		allIdPs = append(allIdPs, page.Result...)
+		page, err = page.GetNextPage()
+		if err != nil {
+			break
+		}
+	}
+
+	var allResources types.Resources
+	for _, idp := range allIdPs {
+		displayName := idp.Name
+		if displayName == "" {
+			displayName = idp.ID
+		}
+		res := types.Resource{
+			Removable:    ZTIdentityProvider{Client: client.ZeroTrust.IdentityProviders},
+			ResourceID:   idp.ID,
+			ResourceName: displayName,
+			AccountID:    creds.AccountID,
+			ProductName:  "ZTIdentityProvider",
+		}
+		allResources = append(allResources, &res)
+	}
+
+	return allResources, nil
+}
+
+func (c ZTIdentityProvider) Remove(accountID string, resourceID string, resourceName string) error {
+	_, err := c.Client.Delete(context.TODO(), resourceID, zero_trust.IdentityProviderDeleteParams{
+		AccountID: cloudflare.F(accountID),
+	})
+
+	return err
+}

--- a/resources/accessPolicy.go
+++ b/resources/accessPolicy.go
@@ -1,0 +1,66 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
+
+	"github.com/arafato/cf-nuke/infrastructure"
+	"github.com/arafato/cf-nuke/types"
+	"github.com/arafato/cf-nuke/utils"
+)
+
+func init() {
+	infrastructure.RegisterAccountCollector("zt-access-policy", CollectZTAccessPolicies)
+}
+
+type ZTAccessPolicy struct {
+	Client *zero_trust.AccessPolicyService
+}
+
+func CollectZTAccessPolicies(creds *types.Credentials) (types.Resources, error) {
+	client := utils.CreateCFClient(creds)
+
+	page, err := client.ZeroTrust.Access.Policies.List(context.TODO(), zero_trust.AccessPolicyListParams{
+		AccountID: cloudflare.F(creds.AccountID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var allPolicies []zero_trust.AccessPolicyListResponse
+	for page != nil && len(page.Result) != 0 {
+		allPolicies = append(allPolicies, page.Result...)
+		page, err = page.GetNextPage()
+		if err != nil {
+			break
+		}
+	}
+
+	var allResources types.Resources
+	for _, policy := range allPolicies {
+		displayName := policy.Name
+		if displayName == "" {
+			displayName = policy.ID
+		}
+		res := types.Resource{
+			Removable:    ZTAccessPolicy{Client: client.ZeroTrust.Access.Policies},
+			ResourceID:   policy.ID,
+			ResourceName: displayName,
+			AccountID:    creds.AccountID,
+			ProductName:  "ZTAccessPolicy",
+		}
+		allResources = append(allResources, &res)
+	}
+
+	return allResources, nil
+}
+
+func (c ZTAccessPolicy) Remove(accountID string, resourceID string, resourceName string) error {
+	_, err := c.Client.Delete(context.TODO(), resourceID, zero_trust.AccessPolicyDeleteParams{
+		AccountID: cloudflare.F(accountID),
+	})
+
+	return err
+}

--- a/resources/accessUser.go
+++ b/resources/accessUser.go
@@ -1,0 +1,80 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
+
+	"github.com/arafato/cf-nuke/infrastructure"
+	"github.com/arafato/cf-nuke/types"
+	"github.com/arafato/cf-nuke/utils"
+)
+
+func init() {
+	infrastructure.RegisterAccountCollector("zt-access-user", CollectZTAccessUsers)
+}
+
+type ZTAccessUser struct {
+	Client  *zero_trust.SeatService
+	SeatUID string
+}
+
+func CollectZTAccessUsers(creds *types.Credentials) (types.Resources, error) {
+	client := utils.CreateCFClient(creds)
+
+	page, err := client.ZeroTrust.Access.Users.List(context.TODO(), zero_trust.AccessUserListParams{
+		AccountID: cloudflare.F(creds.AccountID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var allUsers []zero_trust.AccessUserListResponse
+	for page != nil && len(page.Result) != 0 {
+		allUsers = append(allUsers, page.Result...)
+		page, err = page.GetNextPage()
+		if err != nil {
+			break
+		}
+	}
+
+	var allResources types.Resources
+	for _, user := range allUsers {
+		// Only include users that occupy a seat
+		if !user.AccessSeat && !user.GatewaySeat {
+			continue
+		}
+		displayName := user.Email
+		if displayName == "" {
+			displayName = user.Name
+		}
+		if displayName == "" {
+			displayName = user.ID
+		}
+		res := types.Resource{
+			Removable:    ZTAccessUser{Client: client.ZeroTrust.Seats, SeatUID: user.SeatUID},
+			ResourceID:   user.ID,
+			ResourceName: displayName,
+			AccountID:    creds.AccountID,
+			ProductName:  "ZTAccessUser",
+		}
+		allResources = append(allResources, &res)
+	}
+
+	return allResources, nil
+}
+
+func (c ZTAccessUser) Remove(accountID string, resourceID string, resourceName string) error {
+	_, err := c.Client.Edit(context.TODO(), zero_trust.SeatEditParams{
+		AccountID: cloudflare.F(accountID),
+		Body: []zero_trust.SeatEditParamsBody{
+			{
+				SeatUID:     cloudflare.F(c.SeatUID),
+				AccessSeat:  cloudflare.F(false),
+				GatewaySeat: cloudflare.F(false),
+			},
+		},
+	})
+	return err
+}

--- a/resources/deviceProfile.go
+++ b/resources/deviceProfile.go
@@ -1,0 +1,61 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
+
+	"github.com/arafato/cf-nuke/infrastructure"
+	"github.com/arafato/cf-nuke/types"
+	"github.com/arafato/cf-nuke/utils"
+)
+
+func init() {
+	infrastructure.RegisterAccountCollector("zt-device-profile", CollectZTDeviceProfiles)
+}
+
+type ZTDeviceProfile struct {
+	Client *zero_trust.DevicePolicyCustomService
+}
+
+func CollectZTDeviceProfiles(creds *types.Credentials) (types.Resources, error) {
+	client := utils.CreateCFClient(creds)
+
+	page, err := client.ZeroTrust.Devices.Policies.Custom.List(context.TODO(), zero_trust.DevicePolicyCustomListParams{
+		AccountID: cloudflare.F(creds.AccountID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var allResources types.Resources
+	for _, profile := range page.Result {
+		// Skip the default profile — it cannot be deleted
+		if profile.Default {
+			continue
+		}
+		displayName := profile.Name
+		if displayName == "" {
+			displayName = profile.PolicyID
+		}
+		res := types.Resource{
+			Removable:    ZTDeviceProfile{Client: client.ZeroTrust.Devices.Policies.Custom},
+			ResourceID:   profile.PolicyID,
+			ResourceName: displayName,
+			AccountID:    creds.AccountID,
+			ProductName:  "ZTDeviceProfile",
+		}
+		allResources = append(allResources, &res)
+	}
+
+	return allResources, nil
+}
+
+func (c ZTDeviceProfile) Remove(accountID string, resourceID string, resourceName string) error {
+	_, err := c.Client.Delete(context.TODO(), resourceID, zero_trust.DevicePolicyCustomDeleteParams{
+		AccountID: cloudflare.F(accountID),
+	})
+
+	return err
+}


### PR DESCRIPTION
### Testing

Tested against a live Cloudflare account. All resources were discovered, displayed, and successfully removed.

**Access Policies & Identity Providers:**

```
> ./bin/cf-nuke nuke --mode account -k $YOUR_ACCOUNT_GLOBAL_TOKEN -u $YOUR_EMAIL -a $YOUR_ACCOUNT_ID -c ./config.yaml --no-dry-run
Scan completed in 10s: Found 5 resources in total in account 123456789: To be removed 5, Filtered 0
┌────────────────────┬──────────────────────────────────────┬────────┐
│      PRODUCT       │              ID / NAME               │ STATUS │
├────────────────────┼──────────────────────────────────────┼────────┤
│ ZTAccessPolicy     │ Allow emails: 04/09/2025             │ Ready  │
│ ZTAccessPolicy     │ MFA by DUO                           │ Ready  │
│ ZTAccessPolicy     │ Core                                 │ Ready  │
│ ZTIdentityProvider │ Zoho                                 │ Ready  │
│ ZTIdentityProvider │ 533138aa-014c-4fd6-95f7-5f9870f2fa76 │ Ready  │
└────────────────────┴──────────────────────────────────────┴────────┘

Status: 5 resources in total. Removed 0, In-Progress 0, Filtered 0, Failed 0

Executing actual nuke operation... do you really want to continue (yes/no)?
yes
Nuke operation confirmed.
┌────────────────────┬──────────────────────────────────────┬─────────┐
│      PRODUCT       │              ID / NAME               │ STATUS  │
├────────────────────┼──────────────────────────────────────┼─────────┤
│ ZTAccessPolicy     │ Allow emails: 04/09/2025             │ Removed │
│ ZTAccessPolicy     │ MFA by DUO                           │ Removed │
│ ZTAccessPolicy     │ Core                                 │ Removed │
│ ZTIdentityProvider │ Zoho                                 │ Removed │
│ ZTIdentityProvider │ 533138aa-014c-4fd6-95f7-5f9870f2fa76 │ Removed │
└────────────────────┴──────────────────────────────────────┴─────────┘

Status: 5 resources in total. Removed 5, In-Progress 0, Filtered 0, Failed 0
Process finished.
```

**Device Profiles (dry run):**

```
> ./bin/cf-nuke nuke --mode account -k $YOUR_ACCOUNT_GLOBAL_TOKEN -u $YOUR_EMAIL -a $YOUR_ACCOUNT_ID -c ./config.yaml
Scan completed in 11s: Found 1 resources in total in account 123456789: To be removed 1, Filtered 0
┌─────────────────┬───────────────────────────────────────┬────────┐
│     PRODUCT     │               ID / NAME               │ STATUS │
├─────────────────┼───────────────────────────────────────┼────────┤
│ ZTDeviceProfile │ Onboarding Device profile: 04/09/2025 │ Ready  │
└─────────────────┴───────────────────────────────────────┴────────┘

Status: 1 resources in total. Removed 0, In-Progress 0, Filtered 0, Failed 0

Dry run complete.
```

**Device Profiles (actual nuke):**

```
> ./bin/cf-nuke nuke --mode account -k $YOUR_ACCOUNT_GLOBAL_TOKEN -u $YOUR_EMAIL -a $YOUR_ACCOUNT_ID -c ./config.yaml --no-dry-run
Scan completed in 12s: Found 1 resources in total in account 123456789: To be removed 1, Filtered 0
┌─────────────────┬───────────────────────────────────────┬────────┐
│     PRODUCT     │               ID / NAME               │ STATUS │
├─────────────────┼───────────────────────────────────────┼────────┤
│ ZTDeviceProfile │ Onboarding Device profile: 04/09/2025 │ Ready  │
└─────────────────┴───────────────────────────────────────┴────────┘

Status: 1 resources in total. Removed 0, In-Progress 0, Filtered 0, Failed 0

Executing actual nuke operation... do you really want to continue (yes/no)?
yes
Nuke operation confirmed.
┌─────────────────┬───────────────────────────────────────┬─────────┐
│     PRODUCT     │               ID / NAME               │ STATUS  │
├─────────────────┼───────────────────────────────────────┼─────────┤
│ ZTDeviceProfile │ Onboarding Device profile: 04/09/2025 │ Removed │
└─────────────────┴───────────────────────────────────────┴─────────┘

Status: 1 resources in total. Removed 1, In-Progress 0, Filtered 0, Failed 0
Process finished.
```
